### PR TITLE
feat: support outputting bytes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,8 +64,8 @@ impl UUIDv6 {
         }
     }
 
-    /// Return the next UUIDv6 string
-    pub fn create(&mut self) -> String {
+    /// Return the next bytes UUIDv6 as bytes
+    pub fn create_bytes(&mut self) -> [u8; 16] {
         let mut buf = [0u8; 16];
         let ts = self.ts;
         buf[0..8].copy_from_slice(&(ts << 4).to_be_bytes());
@@ -80,6 +80,12 @@ impl UUIDv6 {
 
         buf[10..].copy_from_slice(&self.node.node_id);
 
+        return buf;
+    }
+
+    /// Return the next UUIDv6 string
+    pub fn create(&mut self) -> String {
+        let buf = self.create_bytes();
         let mut out = [0u8; 4 + 32];
         out[8] = b'-';
         out[13] = b'-';


### PR DESCRIPTION
Signed-off-by: vados <vados@vadosware.io>

Support outputting bytes (`[u8;16]`) for generated UUIDv6s